### PR TITLE
Add shapes to ingestion, add dummy anndata, remove feature presence, fix docs

### DIFF
--- a/docs/usage/basics.py
+++ b/docs/usage/basics.py
@@ -24,6 +24,7 @@ import soma_curation.sc_logging as lg
 from soma_curation.schema import get_schema
 from soma_curation.atlas.crud import AtlasManager
 from soma_curation.dataset.anndataset import AnnDataset
+from soma_curation.constants.constants import dummy_anndata
 
 # Set the log level to info
 lg.info()
@@ -37,24 +38,12 @@ am.create()
 
 # +
 # Assuming that you fetch a cool dataset from somewhere
-import scanpy as sc
-
-anndata = sc.datasets.pbmc3k()
+anndata = dummy_anndata()
 # -
 
-# Create a Phenomic dataset using our schema
-# You should get an error in this case, since the schema does not allow this
-# In this case, we're missing sample_name, disease_name, study_name, gene columns
-dataset = AnnDataset(artifact=anndata, database_schema=db_schema)
-
-# Fixing issues
-anndata.obs["sample_name"] = "sample"
-anndata.obs["study_name"] = "study"
-anndata.obs["disease_name"] = "disease"
-anndata.var["gene"] = anndata.var.index
-anndata.obs["barcode"] = anndata.obs.index
-
-# You met the basic criteria. Great success!
+# Create a Phenomic dataset using our schema, errors will pop up
+# if this dataset does not follow the schema specified in
+# db_schema.VALIDATION_SCHEMA
 dataset = AnnDataset(artifact=anndata, database_schema=db_schema)
 
 # Standardize the columns

--- a/src/soma_curation/constants/__init__.py
+++ b/src/soma_curation/constants/__init__.py
@@ -1,0 +1,1 @@
+from .constants import dummy_anndata

--- a/src/soma_curation/constants/constants.py
+++ b/src/soma_curation/constants/constants.py
@@ -1,0 +1,41 @@
+# src/soma_curation/constants/constants.py
+import importlib.resources
+import pandas as pd
+import anndata as ad
+import numpy as np
+import scipy.sparse as sp
+
+
+def dummy_anndata() -> ad.AnnData:
+    """
+    Create a minimal dummy AnnData object using the dummy_core_geneset.tsv.gz file.
+
+    Returns:
+    -------
+    ad.AnnData
+        An AnnData object with minimal .obs, .var, and .X to satisfy the schema.
+    """
+
+    dummy_path = importlib.resources.files("soma_curation.constants").joinpath("dummy_core_geneset.tsv.gz")
+    genes = pd.read_csv(dummy_path, sep="\t", header=None)[0].tolist()
+
+    obs = pd.DataFrame(
+        {
+            "barcode": ["cell1", "cell2", "cell3"],
+            "sample_name": ["sample1", "sample1", "sample2"],
+            "study_name": ["study1", "study1", "study2"],
+        }
+    )
+    var = pd.DataFrame({"gene": genes}, index=genes)
+    data = np.array(
+        [
+            [1, 0, 2],
+            [0, 3, 1],
+            [2, 0, 0],
+        ]
+    )
+    X = sp.csr_matrix(data)
+
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+
+    return adata


### PR DESCRIPTION
Multiple changes here which came from integrating TileDB SOMA's 1.15 introduction of shapes.
1. Shapes support on ingest
2. Adding a `dummy_anndata` function to constants for testing purposes
3. Modifying `docs/usage/basics.py` to be free of bugs
4. Removing feature presence matrix ingestion since the entire pipeline will be modified (grander issue is under #2)