### PR TITLE
Include `raw_collection_type` in `PipelineConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ raw_data/
 3. Create and use your collection:
 
 ```python
-from soma_curation.collection import MtxCollection, H5adCollection
+from soma_curation.collection import MtxCollection
 
 # For MTX files
 collection = MtxCollection(

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -62,18 +62,13 @@ raw_data/
 ## 3. Create a Collection and Atlas
 
 ```python
-from soma_curation.collection import MtxCollection, H5adCollection
+from soma_curation.collection import MtxCollection
 from soma_curation.atlas.crud import AtlasManager
 
-# Create a collection to manage raw MTX data
-mtx_collection = MtxCollection(
+# Create a collection to manage raw data
+collection = MtxCollection(
     storage_directory="path/to/raw_data",
     db_schema=schema
-)
-
-# Create a collection to manage H5AD files
-h5ad_collection = H5adCollection(
-    storage_directory="path/to/h5ad_files"
 )
 
 # Create an atlas for processed data
@@ -92,16 +87,12 @@ am.create()
 ```python
 from soma_curation.dataset.anndataset import AnnDataset
 
-# Create and standardize a dataset from MTX collection
+# Create and standardize a dataset
 dataset = AnnDataset(
     atlas_manager=am,
-    collection=mtx_collection
+    collection=collection
 )
 dataset.standardize()
-
-# Or directly use an H5AD file from H5adCollection
-h5ad_filename = h5ad_collection.list_h5ad_files()[0]
-adata = h5ad_collection.get_anndata(filename=h5ad_filename)
 ```
 
 ## 5. Ingest Data into Atlas

--- a/src/soma_curation/ingest/ingestion_funcs.py
+++ b/src/soma_curation/ingest/ingestion_funcs.py
@@ -77,7 +77,7 @@ def convert_and_std_mtx_to_h5ad(study_name: str, sample_name: str, pc: PipelineC
     """
     try:
         logger.info(f"[convert_to_h5ad] Processing study='{study_name}', sample='{sample_name}'")
-        adata = pc.mtx_collection.get_anndata(study_name=study_name, sample_name=sample_name)
+        adata = pc.collection.get_anndata(study_name=study_name, sample_name=sample_name)
     except Exception as e:
         logger.error(
             f"Error fetching and assembling study='{study_name}', sample='{sample_name}' from raw storage: {e}"

--- a/src/soma_curation/scripts/multiprocessing_ingest.py
+++ b/src/soma_curation/scripts/multiprocessing_ingest.py
@@ -86,8 +86,8 @@ def main():
             filenames = pickle.load(f)
     else:
         tasks_to_convert = []
-        for study in pc.mtx_collection.list_studies():
-            for sample in pc.mtx_collection.list_samples(study_name=study):
+        for study in pc.collection.list_studies():
+            for sample in pc.collection.list_samples(study_name=study):
                 tasks_to_convert.append((study, sample, pc))
                 logger.info(f"Adding {(study, sample)} to the multiprocessing queue.")
 

--- a/tests/test_mtx_collection.py
+++ b/tests/test_mtx_collection.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from src.soma_curation.collection.mtx_collection import MtxCollection
+from src.soma_curation.collection import MtxCollection
 from src.soma_curation.schema import load_schema
 from src.soma_curation.constants.create_dummy_structure import create_dummy_structure
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -19,7 +19,7 @@ class DummyResult:
 # Patch the MtxCollection so that list_studies and list_samples return dummy values.
 @pytest.fixture
 def dummy_mtx_collection(monkeypatch):
-    from src.soma_curation.collection.mtx_collection import MtxCollection
+    from src.soma_curation.collection import MtxCollection
 
     monkeypatch.setattr(MtxCollection, "list_studies", lambda self: ["study1"])
     monkeypatch.setattr(MtxCollection, "list_samples", lambda self, study_name: ["sample1"])


### PR DESCRIPTION
- Improved `PipelineConfig` by allowing specification of `raw_collection_type`
- Allowed to specify `H5ad` or `Mtx` collections